### PR TITLE
Callbacks

### DIFF
--- a/lib/lolsoap/callbacks.rb
+++ b/lib/lolsoap/callbacks.rb
@@ -29,7 +29,7 @@ class LolSoap::Callbacks
     end
   end
 
-  # Stores, removes and selects the callback hashes in the class ivar.
+  # Stores, removes and selects the callback hashes in current thread.
   class << self
     Thread.current[:registered] = []
 

--- a/lib/lolsoap/callbacks.rb
+++ b/lib/lolsoap/callbacks.rb
@@ -35,7 +35,7 @@ class LolSoap::Callbacks
 
     def in(key)
       Selected.new(
-        Thread.current[:registered].flat_map { |c| c.callbacks[key] }
+        Thread.current[:registered].flat_map { |c| c.callbacks[key] }.compact
       )
     end
 

--- a/lib/lolsoap/callbacks.rb
+++ b/lib/lolsoap/callbacks.rb
@@ -1,6 +1,26 @@
+# Used to add user processing in definded hooks.
+#
+# @example General
+#  bing_ads_callbacks = LolSoap::Callbacks.new
+#  bing_ads_callbacks.for('hash_params.before_build') << lambda do |args, node, type|
+#    # I want to use snake case !
+#    matcher = type.elements.keys.map { |name| name.tr('_', '').downcase }
+#    args.each do |h|
+#      found_at = matcher.index(h[:name].tr('_', '').downcase)
+#      h[:name] = type.elements.keys[found_at] if found_at
+#    end
+#    # This API accepts the nodes only in the right order.
+#    args.sort_by! { |h| type.elements.keys.index(h[:name]) || 1 / 0.0 }
+#  end
+#
+# @example Managing callback sets
+# bing_ads_callbacks.disable
+# google_ads_callbacks.enable
+#
 class LolSoap::Callbacks
   @registered = []
 
+  # Aggregates all callbacks on the selected key to call them.
   class Selected
     def initialize(callbacks = [])
       @callbacks = callbacks
@@ -11,10 +31,11 @@ class LolSoap::Callbacks
     end
   end
 
+  # Stores, removes and selects the callbacks hashes in the class ivar
   class << self
     def in(key)
       Selected.new(
-        @registered.map { |c| c.procs[key] }.flatten
+        @registered.flat_map { |c| c.procs[key] }
       )
     end
 
@@ -27,13 +48,14 @@ class LolSoap::Callbacks
     end
   end
 
+  # Manages callbacks in insatances so we can manage sets of callbacks.
   def initialize
     enable
     @procs = {}
   end
 
   attr_accessor :procs
-
+  # @param key [String] the unique self explanatory name of the hook
   def for(key)
     procs[key] ||= []
   end

--- a/lib/lolsoap/callbacks.rb
+++ b/lib/lolsoap/callbacks.rb
@@ -1,4 +1,3 @@
-require 'byebug'
 # Used to add user processing in defined hooks.
 #
 # @example General

--- a/lib/lolsoap/callbacks.rb
+++ b/lib/lolsoap/callbacks.rb
@@ -50,7 +50,7 @@ class LolSoap::Callbacks
 
   attr_reader :callbacks
 
-  # Manages callbacks in insatances so we can manage sets of callbacks.
+  # Manages callbacks in instances so we can manage sets of callbacks.
   def initialize
     @callbacks = {}
     enable

--- a/lib/lolsoap/callbacks.rb
+++ b/lib/lolsoap/callbacks.rb
@@ -1,3 +1,4 @@
+require 'byebug'
 # Used to add user processing in defined hooks.
 #
 # @example General
@@ -18,8 +19,6 @@
 # google_ads_callbacks.enable
 #
 class LolSoap::Callbacks
-  @registered = []
-
   # Aggregates all callbacks on the selected key to call them.
   class Selected
     def initialize(callbacks = [])
@@ -33,18 +32,20 @@ class LolSoap::Callbacks
 
   # Stores, removes and selects the callback hashes in the class ivar.
   class << self
+    Thread.current[:registered] = []
+
     def in(key)
       Selected.new(
-        @registered.flat_map { |c| c.callbacks[key] }
+        Thread.current[:registered].flat_map { |c| c.callbacks[key] }
       )
     end
 
     def register(*klass)
-      @registered |= klass
+      Thread.current[:registered] |= klass
     end
 
     def unregister(klass)
-      @registered.delete(klass)
+      Thread.current[:registered].delete(klass)
     end
   end
 

--- a/lib/lolsoap/callbacks.rb
+++ b/lib/lolsoap/callbacks.rb
@@ -1,0 +1,46 @@
+class LolSoap::Callbacks
+  @registered = []
+
+  class Selected
+    def initialize(callbacks = [])
+      @callbacks = callbacks
+    end
+
+    def expose(*args)
+      @callbacks.each { |c| c.call(*args) }
+    end
+  end
+
+  class << self
+    def in(key)
+      Selected.new(*@registered.map { |c| c.procs[key] })
+    end
+
+    def register(*klass)
+      @registered |= klass
+    end
+
+    def unregister(klass)
+      @registered.delete(klass)
+    end
+  end
+
+  def initialize
+    enable
+    @procs = {}
+  end
+
+  attr_accessor :procs
+
+  def for(key)
+    procs[key] ||= []
+  end
+
+  def enable
+    self.class.register(self)
+  end
+
+  def disable
+    self.class.unregister(self)
+  end
+end

--- a/lib/lolsoap/callbacks.rb
+++ b/lib/lolsoap/callbacks.rb
@@ -13,7 +13,9 @@ class LolSoap::Callbacks
 
   class << self
     def in(key)
-      Selected.new(*@registered.map { |c| c.procs[key] })
+      Selected.new(
+        @registered.map { |c| c.procs[key] }.flatten
+      )
     end
 
     def register(*klass)

--- a/lib/lolsoap/callbacks.rb
+++ b/lib/lolsoap/callbacks.rb
@@ -31,7 +31,7 @@ class LolSoap::Callbacks
     end
   end
 
-  # Stores, removes and selects the callbacks hashes in the class ivar
+  # Stores, removes and selects the callbacks hashes in the class ivar.
   class << self
     def in(key)
       Selected.new(
@@ -56,7 +56,7 @@ class LolSoap::Callbacks
     enable
   end
 
-  # @param key [String] the unique self explanatory name of the hook
+  # @param key [String] the unique self explanatory name of the hook.
   def for(key)
     callbacks[key] ||= []
   end

--- a/lib/lolsoap/callbacks.rb
+++ b/lib/lolsoap/callbacks.rb
@@ -1,4 +1,4 @@
-# Used to add user processing in definded hooks.
+# Used to add user processing in defined hooks.
 #
 # @example General
 #  bing_ads_callbacks = LolSoap::Callbacks.new
@@ -31,7 +31,7 @@ class LolSoap::Callbacks
     end
   end
 
-  # Stores, removes and selects the callbacks hashes in the class ivar.
+  # Stores, removes and selects the callback hashes in the class ivar.
   class << self
     def in(key)
       Selected.new(

--- a/lib/lolsoap/callbacks.rb
+++ b/lib/lolsoap/callbacks.rb
@@ -31,6 +31,8 @@ class LolSoap::Callbacks
 
   # Selects the callback hashes in current thread.
   def self.in(key)
+    Thread.current[:registered_callbacks] ||= []
+
     Selected.new(
       Thread.current[:registered_callbacks].flat_map do |c|
         c.callbacks[key]

--- a/lib/lolsoap/callbacks.rb
+++ b/lib/lolsoap/callbacks.rb
@@ -35,7 +35,7 @@ class LolSoap::Callbacks
   class << self
     def in(key)
       Selected.new(
-        @registered.flat_map { |c| c.procs[key] }
+        @registered.flat_map { |c| c.callbacks[key] }
       )
     end
 
@@ -48,16 +48,17 @@ class LolSoap::Callbacks
     end
   end
 
+  attr_reader :callbacks
+
   # Manages callbacks in insatances so we can manage sets of callbacks.
   def initialize
+    @callbacks = {}
     enable
-    @procs = {}
   end
 
-  attr_accessor :procs
   # @param key [String] the unique self explanatory name of the hook
   def for(key)
-    procs[key] ||= []
+    callbacks[key] ||= []
   end
 
   def enable

--- a/test/unit/test_callbacks.rb
+++ b/test/unit/test_callbacks.rb
@@ -1,5 +1,6 @@
 require 'helper'
 require 'lolsoap/callbacks.rb'
+require 'byebug'
 
 module LolSoap
   describe Callbacks do
@@ -44,6 +45,47 @@ module LolSoap
       temp.disable
     end
 
+    it 'can keeep the order on clear' do
+      temp = Callbacks.new
+      temp.for('a.b') << ->(name, mutable) { mutable << "#{name} more" }
+      ary = []
+      Callbacks.in('a.b').expose('lol', ary)
+      ary.must_equal ['Lol lol', 'lol more']
+      @lol_callbacks.for('a.b').clear
+      ary = []
+      Callbacks.in('a.b').expose('lol', ary)
+      ary.must_equal ['lol more']
+      @lol_callbacks.for('a.b') << ->(name, mutable) { mutable << "Lol #{name}" }
+      ary = []
+      Callbacks.in('a.b').expose('lol', ary)
+      ary.must_equal ['Lol lol', 'lol more']
+      temp.disable
+    end
+
+    it 'can keeep the order on clear in a thread' do
+      Thread.new do
+        lol_callbacks = Callbacks.new.tap do |lc|
+          lc.for('a.b') << ->(name, mutable) { mutable << "Lol #{name}" }
+        end
+
+        temp = Callbacks.new
+        temp.for('a.b') << ->(name, mutable) { mutable << "#{name} more" }
+        ary = []
+        Callbacks.in('a.b').expose('lol', ary)
+        ary.must_equal ['Lol lol', 'lol more']
+        lol_callbacks.for('a.b').clear
+        ary = []
+        Callbacks.in('a.b').expose('lol', ary)
+        ary.must_equal ['lol more']
+        lol_callbacks.for('a.b') << ->(name, mutable) { mutable << "Lol #{name}" }
+        ary = []
+        Callbacks.in('a.b').expose('lol', ary)
+        ary.must_equal ['Lol lol', 'lol more']
+        lol_callbacks.disable
+        temp.disable
+      end.join
+    end
+
     it 'can route callbacks' do
       temp = Callbacks.new
       temp.for('c.d') << ->(name, mutable) { mutable << "#{name} c.D" }
@@ -63,6 +105,17 @@ module LolSoap
       ary = []
       Callbacks.in('a.b').expose('lol', ary)
       ary.must_equal ['any lol ?']
+      temp.disable
+    end
+
+    it "can't keep the order on enable" do
+      @lol_callbacks.disable
+      temp = Callbacks.new
+      temp.for('a.b') << ->(name, mutable) { mutable << "any #{name} ?" }
+      ary = []
+      @lol_callbacks.enable
+      Callbacks.in('a.b').expose('lol', ary)
+      ary.must_equal ['any lol ?', 'Lol lol']
       temp.disable
     end
 

--- a/test/unit/test_callbacks.rb
+++ b/test/unit/test_callbacks.rb
@@ -1,14 +1,17 @@
 require 'helper'
 require 'lolsoap/callbacks.rb'
-require 'byebug'
 
 module LolSoap
   describe Callbacks do
     before do
-      load 'lolsoap/callbacks.rb'
       @lol_callbacks = Callbacks.new.tap do |lc|
         lc.for('a.b') << ->(name, mutable) { mutable << "Lol #{name}" }
       end
+    end
+
+    after do
+      @lol_callbacks.disable
+      @lol_callbacks = nil
     end
 
     it 'can store one callback' do
@@ -25,10 +28,20 @@ module LolSoap
       ary.must_equal ['Lol lol']
     end
 
+    it 'can call multiple callbacks' do
+      temp = Callbacks.new
+      temp.for('a.b') << ->(name, mutable) { mutable << "#{name} more" }
+      temp.for('a.b') << ->(name, mutable) { mutable << "#{name} again" }
+      ary = []
+      Callbacks.in('a.b').expose('lol', ary)
+      ary.must_equal ['Lol lol', 'lol more', 'lol again']
+      temp.disable
+      temp = nil
+    end
+
     it 'can be disabled' do
       @lol_callbacks.disable
       Callbacks.instance_variable_get(:@registered).size.must_equal 0
-      @lol_callbacks.enable
     end
 
     it 'can be enabled' do

--- a/test/unit/test_callbacks.rb
+++ b/test/unit/test_callbacks.rb
@@ -1,6 +1,5 @@
 require 'helper'
 require 'lolsoap/callbacks.rb'
-require 'byebug'
 
 module LolSoap
   describe Callbacks do

--- a/test/unit/test_callbacks.rb
+++ b/test/unit/test_callbacks.rb
@@ -33,6 +33,18 @@ module LolSoap
       temp.disable
     end
 
+    it 'can route callbacks' do
+      temp = Callbacks.new
+      temp.for('c.d') << ->(name, mutable) { mutable << "#{name} c.D" }
+      ary = []
+      yra = []
+      Callbacks.in('c.d').expose('lol', yra)
+      Callbacks.in('a.b').expose('lol', ary)
+      ary.must_equal ['Lol lol']
+      yra.must_equal ['lol c.D']
+      temp.disable
+    end
+
     it 'can be disabled' do
       @lol_callbacks.disable
       temp = Callbacks.new

--- a/test/unit/test_callbacks.rb
+++ b/test/unit/test_callbacks.rb
@@ -11,15 +11,10 @@ module LolSoap
 
     after do
       @lol_callbacks.disable
-      @lol_callbacks = nil
     end
 
     it 'can store one callback' do
-      @lol_callbacks.procs.size.must_equal 1
-    end
-
-    it 'can regiter the callback' do
-      Callbacks.instance_variable_get(:@registered).size.must_equal 1
+      @lol_callbacks.callbacks.size.must_equal 1
     end
 
     it 'can call a callback' do
@@ -36,18 +31,27 @@ module LolSoap
       Callbacks.in('a.b').expose('lol', ary)
       ary.must_equal ['Lol lol', 'lol more', 'lol again']
       temp.disable
-      temp = nil
     end
 
     it 'can be disabled' do
       @lol_callbacks.disable
-      Callbacks.instance_variable_get(:@registered).size.must_equal 0
+      temp = Callbacks.new
+      temp.for('a.b') << ->(name, mutable) { mutable << "any #{name} ?" }
+      ary = []
+      Callbacks.in('a.b').expose('lol', ary)
+      ary.must_equal ['any lol ?']
+      temp.disable
     end
 
     it 'can be enabled' do
       @lol_callbacks.disable
       @lol_callbacks.enable
-      Callbacks.instance_variable_get(:@registered).size.must_equal 1
+      temp = Callbacks.new
+      temp.for('a.b') << ->(name, mutable) { mutable << "any #{name} ?" }
+      ary = []
+      Callbacks.in('a.b').expose('lol', ary)
+      ary.must_equal ['Lol lol', 'any lol ?']
+      temp.disable
     end
   end
 end

--- a/test/unit/test_callbacks.rb
+++ b/test/unit/test_callbacks.rb
@@ -1,0 +1,40 @@
+require 'helper'
+require 'lolsoap/callbacks.rb'
+require 'byebug'
+
+module LolSoap
+  describe Callbacks do
+    before do
+      load 'lolsoap/callbacks.rb'
+      @lol_callbacks = Callbacks.new.tap do |lc|
+        lc.for('a.b') << ->(name, mutable) { mutable << "Lol #{name}" }
+      end
+    end
+
+    it 'can store one callback' do
+      @lol_callbacks.procs.size.must_equal 1
+    end
+
+    it 'can regiter the callback' do
+      Callbacks.instance_variable_get(:@registered).size.must_equal 1
+    end
+
+    it 'can call a callback' do
+      ary = []
+      Callbacks.in('a.b').expose('lol', ary)
+      ary.must_equal ['Lol lol']
+    end
+
+    it 'can be disabled' do
+      @lol_callbacks.disable
+      Callbacks.instance_variable_get(:@registered).size.must_equal 0
+      @lol_callbacks.enable
+    end
+
+    it 'can be enabled' do
+      @lol_callbacks.disable
+      @lol_callbacks.enable
+      Callbacks.instance_variable_get(:@registered).size.must_equal 1
+    end
+  end
+end

--- a/test/unit/test_callbacks.rb
+++ b/test/unit/test_callbacks.rb
@@ -23,6 +23,17 @@ module LolSoap
       ary.must_equal ['Lol lol']
     end
 
+    it 'can call a callback in a thread' do
+      ary = []
+      Thread.new do
+        Callbacks.new.tap do |lc|
+          lc.for('a.b') << ->(name, mutable) { mutable << "Lol #{name}" }
+        end
+        Callbacks.in('a.b').expose('lol', ary)
+      end.join
+      ary.must_equal ['Lol lol']
+    end
+
     it 'can call multiple callbacks' do
       temp = Callbacks.new
       temp.for('a.b') << ->(name, mutable) { mutable << "#{name} more" }


### PR DESCRIPTION
Hi,
this feature allows user processing where necessary.
I don't think the features we need belongs in Lolsoap but they are easier / fastest inside Lolsoap.
We need this in order to :
 * Sort soap nodes since it's needed by Bing Ads api
 * Allow some rubysh syntax sugar in hash syntax builder

Example :
```
bing_ads_callbacks = LolSoap::Callbacks.new
bing_ads_callbacks.for('hash_params.before_build') << lambda do |args, node, type|
  matcher = type.elements.keys.map{ |name| name.tr('_', '').downcase }
  args.each do |h|
    found_at = matcher.index(h[:name].tr('_', '').downcase)
    h[:name] = type.elements.keys[found_at] if found_at
  end
  args.sort_by! { |h| type.elements.keys.index(h[:name]) || 1 / 0.0 }
end
```